### PR TITLE
Add loot fixes

### DIFF
--- a/src/actions/lootActions.ts
+++ b/src/actions/lootActions.ts
@@ -39,16 +39,21 @@ export const addLootItem = async ({
   source,
   acquired_at,
   quantity,
+  status,
+  sold_at,
 }: {
   itemTypeId: number;
   source?: string;
   acquired_at: string;
   quantity?: number;
+  status?: string;
+  sold_at?: string;
 }) => {
   const { error } = await supabase.from("loot").insert([
     {
       item_type_id: itemTypeId,
-      status: "В наличии",
+      status: status ?? "В наличии",
+      sold_at: sold_at ?? null,
       source,
       acquired_at: new Date(acquired_at).toISOString(),
       quantity: quantity ?? 1,

--- a/src/widgets/Loot/GuildLoot/AddLootDialog.tsx
+++ b/src/widgets/Loot/GuildLoot/AddLootDialog.tsx
@@ -37,6 +37,8 @@ export function AddLootDialog({
   const getItemTypeIdByName = (name: string): number | undefined =>
     itemTypes.find((item) => item.name === name)?.id;
 
+  const isOtherType = form.itemName === "Другое";
+
   const handleSelect = (name: string) => {
     const id = getItemTypeIdByName(name);
     if (!id) {
@@ -49,7 +51,15 @@ export function AddLootDialog({
     if (!form.itemTypeId) {
       return alert("Выберите предмет из списка!");
     }
-    await onAdd(form);
+    let itemToAdd = { ...form };
+    if (isOtherType) {
+      itemToAdd = {
+        ...itemToAdd,
+        status: "Продано",
+        sold_at: new Date().toISOString(),
+      };
+    }
+    await onAdd(itemToAdd);
     onClose();
     setForm({
       itemTypeId: 0,
@@ -99,7 +109,7 @@ export function AddLootDialog({
             }
           />
 
-          <Label>Количество</Label>
+          <Label>{isOtherType ? "Сумма дохода" : "Количество"}</Label>
           <input
             type="number"
             min={1}
@@ -108,6 +118,7 @@ export function AddLootDialog({
               setForm({ ...form, quantity: parseInt(e.target.value) })
             }
             className="border rounded px-2 py-1"
+            placeholder={isOtherType ? "Введите сумму дохода" : "Количество"}
           />
         </div>
         <DialogFooter>

--- a/src/widgets/Loot/GuildLoot/LootTypes.ts
+++ b/src/widgets/Loot/GuildLoot/LootTypes.ts
@@ -41,4 +41,6 @@ export type NewLootItem = {
   acquired_at: string;
   quantity: number;
   itemName: string;
+  status?: string;
+  sold_at?: string;
 };

--- a/src/widgets/Loot/LootBuy/icons/LootIcons.ts
+++ b/src/widgets/Loot/LootBuy/icons/LootIcons.ts
@@ -23,6 +23,7 @@ const LootGrade: { [key: string]: number } = {
 };
 
 export const LootIcons: { [key: string]: string | number } = {
+  "Другое": 4383,
   "Глайдер «Крылья небесного стража»": 4312,
   "Аметистовая гравировка северной звезды": 4190,
   "Средоточие безумия": 4773,


### PR DESCRIPTION
This pull request introduces enhancements to the loot management workflow, specifically handling the "Другое" (Other) item type as sold loot and improving the user interface for adding such items. The changes ensure that when "Другое" is selected, the item is automatically marked as sold, records the sale date, and updates form labels and placeholders for clarity. Additionally, new fields are added to support these features throughout the codebase.